### PR TITLE
cleanタスクで、del()のオプションを指定できるようにします。

### DIFF
--- a/lib/tasks/clean.js
+++ b/lib/tasks/clean.js
@@ -21,7 +21,7 @@ module.exports = function (config) {
       timer.end('clean');
       return observer.next(config.src);
     }
-    del(config.src).then((paths) => {
+    del(config.src, config.options).then((paths) => {
       spinner.succeed();
       timer.end('clean');
       observer.next(config.src);


### PR DESCRIPTION
ワーキングディレクトリ外に書き出しを行うケースでは、下記のように書き出したファイルの削除ができない場合があったためです。
```
Error: Cannot delete files/folders outside the current working directory. Can be overriden with the `force` option.
```