### PR TITLE
Update version of node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "karma-phantomjs-launcher": "1.0.2",
     "karma-webpack": "1.8.1",
     "mkdirp": "0.5.1",
-    "node-sass": "4.1.1",
+    "node-sass": "4.5",
     "ora": "0.4.0",
     "phantomjs-prebuilt": "2.1.14",
     "postcss": "5.2.8",


### PR DESCRIPTION
node-sassの古いバージョンでメモリリークするバグがありビルドが失敗します。

https://stackoverflow.com/questions/41472027/webpack-sass-building-fails-intermittently-on-linux-only-module-build-failed/41689062#41689062